### PR TITLE
Update aamva.py

### DIFF
--- a/aamva/aamva.py
+++ b/aamva/aamva.py
@@ -665,6 +665,8 @@ class AAMVA:
             sex = MALE
         if sex == "2":
             sex = FEMALE
+        if sex == "9":
+            sex = NOT_SPECIFIED
 
         # Some v.03 barcodes (Indiana) [wrongly, and stupidly] omit
         # the mandatory height (DAU) field.


### PR DESCRIPTION
2016 spec included value of 9 for Not Specified gender. VA for example uses this as non-binary marker